### PR TITLE
reworked admin auth

### DIFF
--- a/src/auth/admin/admin-auth/admin-auth.service.spec.ts
+++ b/src/auth/admin/admin-auth/admin-auth.service.spec.ts
@@ -65,14 +65,21 @@ describe('AdminAuthService', () => {
   });
 
   it('should retry request after logging in if the request failed with an unauthorized status code', async () => {
-    const config = { url: 'https://example.com' };
+    const config = {
+      url: 'https://example.com',
+      headers: { Authorization: 'old-token ' },
+    };
     const response = { status: HttpStatus.UNAUTHORIZED };
     jest.spyOn(service, 'login');
 
     await rejectedCallback({ config, response });
 
     expect(service.login).toHaveBeenCalled();
-    expect(mockHttpService.request).toHaveBeenCalledWith(config);
+    // old authorization token is deleted
+    expect(mockHttpService.request).toHaveBeenCalledWith({
+      url: config.url,
+      headers: {},
+    });
   });
 
   it('should just return the exception if request was to an openid-connect endpoint and failed', () => {

--- a/src/auth/admin/admin-auth/admin-auth.service.ts
+++ b/src/auth/admin/admin-auth/admin-auth.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
-import { catchError, map, Observable } from 'rxjs';
+import { concatMap, lastValueFrom, map, Observable, tap } from 'rxjs';
 import { OIDCTokenResponse } from '../oidc-token-response.dto';
 import { ConfigService } from '@nestjs/config';
 
@@ -11,15 +11,30 @@ import { ConfigService } from '@nestjs/config';
 @Injectable()
 export class AdminAuthService {
   private readonly keycloakUrl: string;
-  accessToken: string;
-  refreshToken: string;
-  refreshTokenTimeout;
 
   constructor(private http: HttpService, configService: ConfigService) {
     this.keycloakUrl = configService.get('KEYCLOAK_URL');
     const username = configService.get('KEYCLOAK_ADMIN');
     const password = configService.get('KEYCLOAK_PASSWORD');
-    this.login(username, password);
+    this.http.axiosRef.interceptors.response.use(
+      (res) => res,
+      (err) => {
+        // intercept requests where the admin token might have timed out
+        if (
+          err.response.status !== HttpStatus.UNAUTHORIZED ||
+          err.config.url.match(/openid-connect/)
+        ) {
+          // these errors should just be returned
+          throw err;
+        }
+        // retry request after logging in
+        return lastValueFrom(
+          this.login(username, password).pipe(
+            concatMap(() => this.http.request(err.config)),
+          ),
+        );
+      },
+    );
   }
 
   /**
@@ -30,57 +45,22 @@ export class AdminAuthService {
    * @returns OIDCTokenResponse
    */
   login(username: string, password: string): Observable<OIDCTokenResponse> {
-    return this.credentialAuth(username, password);
-  }
-
-  private credentialAuth(username: string, password: string) {
     const body = new URLSearchParams();
     body.set('username', username);
     body.set('password', password);
     body.set('grant_type', 'password');
-    return this.getToken(body);
-  }
-
-  private refreshTokenAuth() {
-    const body = new URLSearchParams();
-    body.set('refresh_token', this.refreshToken);
-    body.set('grant_type', 'refresh_token');
-    return this.getToken(body);
-  }
-
-  private getToken(body: URLSearchParams): Observable<OIDCTokenResponse> {
     body.set('client_id', 'admin-cli');
-    const obs = this.http
+    return this.http
       .post<OIDCTokenResponse>(
         `${this.keycloakUrl}/realms/master/protocol/openid-connect/token`,
         body.toString(),
       )
       .pipe(
         map((res) => res.data),
-        catchError(() => {
-          throw new UnauthorizedException();
+        tap(({ access_token }) => {
+          this.http.axiosRef.defaults.headers.common['Authorization'] =
+            'Bearer ' + access_token;
         }),
       );
-    obs.subscribe({
-      next: (res) => {
-        this.accessToken = res.access_token;
-        this.refreshToken = res.refresh_token;
-        this.http.axiosRef.defaults.headers.common['Authorization'] =
-          'Bearer ' + this.accessToken;
-        this.refreshTokenBeforeExpiry(res.expires_in);
-      },
-      error: () => undefined,
-    });
-    return obs;
-  }
-
-  private refreshTokenBeforeExpiry(secondsTillExpiration: number) {
-    // Refresh token one minute before it expires or after ten seconds
-    const refreshTimeout = Math.max(50, secondsTillExpiration - 60);
-    clearTimeout(this.refreshTokenTimeout);
-    this.refreshTokenTimeout = setTimeout(
-      () => this.refreshTokenAuth(),
-      refreshTimeout * 1000,
-    );
   }
 }

--- a/src/auth/admin/admin-auth/admin-auth.service.ts
+++ b/src/auth/admin/admin-auth/admin-auth.service.ts
@@ -27,7 +27,8 @@ export class AdminAuthService {
           // these errors should just be returned
           throw err;
         }
-        // retry request after logging in
+        // receive new access_token and retry request
+        delete err.config.headers.Authorization;
         return lastValueFrom(
           this.login(username, password).pipe(
             concatMap(() => this.http.request(err.config)),
@@ -39,7 +40,7 @@ export class AdminAuthService {
 
   /**
    * Login the admin with the given credentials.
-   * After successful login, the session is kept alive using refresh tokens.
+   * The received access_token is set as a default header for all outgoing http requests.
    * @param username of admin
    * @param password of admin
    * @returns OIDCTokenResponse

--- a/src/auth/admin/oidc-token-response.dto.ts
+++ b/src/auth/admin/oidc-token-response.dto.ts
@@ -6,12 +6,4 @@ export class OIDCTokenResponse {
    * The actual access token which provides access.
    */
   access_token: string;
-  /**
-   * The time until the access token expires.
-   */
-  expires_in: number;
-  /**
-   * A token that can be used to retrieve a new access token.
-   */
-  refresh_token: string;
 }


### PR DESCRIPTION
The previous admin auth has been done using a single login call and then the session was kept active using `refresh_tokens`. This broke sometimes leaving the service in an unusable state.

The new auth flow waits for requests to return a `401` (unauthorised) error. In this case a new `access_token` is requested and the request is repeated with the new token. This has the benefit that less state is needed and the session does not need to be kept alive for the live-time of the service.

Optionally the admin auth using username and password can now easily be replaced using a confidential client and a client secret (see #3).