### PR TITLE
Flexible user accounts

### DIFF
--- a/src/account/account.controller.spec.ts
+++ b/src/account/account.controller.spec.ts
@@ -82,7 +82,7 @@ describe('AccountController', () => {
     expect(res).toEqual({ roles, ...requestedUser });
     expect(mockHttp.get).toHaveBeenCalledWith(
       expect.stringMatching(/\/users$/),
-      { params: { username: 'my-user', exact: true } },
+      { params: { q: 'exact_username:my-user', exact: true } },
     );
     expect(mockHttp.get).toHaveBeenCalledWith(
       expect.stringMatching(/\/users\/user-id\/role-mappings\/realm$/),

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -142,7 +142,9 @@ export class AccountController {
   ): Promise<KeycloakUser> {
     const user = req.user as User;
     const account = await firstValueFrom(
-      this.keycloak.findUserBy(user.realm, { username }),
+      this.keycloak.findUserBy(user.realm, {
+        q: `exact_username:${username}`,
+      }),
     );
     const roles = await firstValueFrom(
       this.keycloak.getRolesOfUser(user.realm, account.id),

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -54,7 +54,6 @@ export class AccountController {
   @Put('set-email')
   setEmail(@Req() req, @Body() { email }: SetEmailReq) {
     const user = req.user as User;
-    // TODO email is directly marked as verified
     return this.keycloak
       .updateUser(user.realm, user.sub, {
         email: email,


### PR DESCRIPTION
currently users are searched by their username. This has been changed to match with the custom `exact_username` property.